### PR TITLE
Be more lenient when reading serial-numbers

### DIFF
--- a/disk-burnin.sh
+++ b/disk-burnin.sh
@@ -157,7 +157,7 @@ if [ -z "$Disk_Model" ]; then
   Disk_Model=$(smartctl -i /dev/"$Drive" | grep "Model Family" | awk '{print $3, $4, $5}' | sed -e 's/^[ \t]*//;s/[ \t]*$//' | sed -e 's/ /_/')
 fi
 
-Serial_Number=$(smartctl -i /dev/"$Drive" | grep "Serial Number" | awk '{print $3}' | sed -e 's/ /_/')
+Serial_Number=$(smartctl -i /dev/"$Drive" | grep --ignore-case "Serial Number" | awk '{print $3}' | sed -e 's/ /_/')
 
 # Form the log and bad blocks data filenames:
 


### PR DESCRIPTION
This is done to allow the log file to be generated uniqely even if the info is a bit hard to get.