### PR TITLE
Remove code duplication and dependencies; improve portability, readability and docs; add option parsing, dependency and sudo check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -1,26 +1,30 @@
 # Shell script for burn-in and testing of drives
+
 ## Purpose
-`disk-burnin.sh` is a POSIX-compliant shell script I wrote to simplify the process of burning-in disks. It is intended for use only on disks which do not contain data, such as new disks or disks which are being tested or re-purposed. I was inspired by the ["How To: Hard Drive Burn-In Testing"](https://forums.freenas.org/index.php?threads/how-to-hard-drive-burn-in-testing.21451/) thread on the FreeNAS forum and I want to give full props to the good folks who contributed to that thread. 
+
+`disk-burnin.sh` is a POSIX-compliant shell script I wrote to simplify the process of burning-in disks. It is intended for use only on disks which do not contain data, such as new disks or disks which are being tested or re-purposed. I was inspired by the ["How To: Hard Drive Burn-In Testing"](https://forums.freenas.org/index.php?threads/how-to-hard-drive-burn-in-testing.21451/) thread on the FreeNAS forum and I want to give full props to the good folks who contributed to that thread.
 
 ## Warnings
-Be warned that:                                                             
-                                                                           
+
+Be warned that:
+
 * This script runs the `badblocks` program in destructive mode, which erases any data on the disk. Therefore, please be careful! __Do not run this script on disks containing data you value!__
-* Run times for large disks can take several days to a week or more to complete, so it is a good idea to use `tmux` sessions to prevent mishaps.               
-* Must be run as 'root', so either log on using the root account or use the `sudo` command, for example: `sudo ./disk_burnin.sh sda`                                          
-         
-## Tests         
-Performs these steps:                                                      
-                                                                           
+* Run times for large disks can take several days to a week or more to complete, so it is a good idea to use `tmux` sessions to prevent mishaps.
+* Must be run as 'root', so either log on using the root account or use the `sudo` command, for example: `sudo ./disk_burnin.sh sda`
+
+## Tests
+
+Performs these steps:
+
 1. Run SMART short test
-1. Run `badblocks`                                             
-1. Run SMART extended test                                               
+2. Run `badblocks`
+3. Run SMART extended test
 
 The script calls `sleep` after starting each SMART test, using a duration based on the polling interval reported by the disk, after which it polls for test completion.
 
-Full SMART information is pulled after each SMART test. All output except for the `sleep` command is echoed to both the screen and log file.    
-                                                                           
-You should periodically monitor the burn-in progress and check for errors, particularly any errors reported by `badblocks`, or these SMART errors:                   
+Full SMART information is pulled after each SMART test. All output except for the `sleep` command is echoed to both the screen and log file.
+
+You should periodically monitor the burn-in progress and check for errors, particularly any errors reported by `badblocks`, or these SMART errors:
   
 |ID|Attribute Name|
 |---:|---|
@@ -28,32 +32,34 @@ You should periodically monitor the burn-in progress and check for errors, parti
 |196|Reallocated_Event_Count|
 |197|Current_Pending_Sector|
 |198|Offline_Uncorrectable|
-                                                                           
+
 These indicate possible problems with the drive. You therefore may wish to abort the remaining tests and proceed with an RMA exchange for new drives or discard old ones. Also please note that this list is not exhaustive.
-                                                                           
+
 The script extracts the drive model and serial number and creates a log filename of the form `burnin-[model]_[serial number].log`.
 
 ## `badblocks` Options
+
 `badblocks` is invoked with the following options:
-- `-b 4096` : Use a block size of 4096
-- `-e 1` : Abort the test if an error is found (remove this option for full testing of drives)
-- `-v` : Verbose mode
-- `-o` : Write list of bad blocks found (if any) to a file named `burnin-[model]_[serial number].bb`
-- `-s` : Show progress
-- `-w` : Write-mode test, writes four patterns (0xaa, 0x55, 0x44, 0x00) on every disk block
-                                                                           
+
+* `-b 4096` : Use a block size of 4096
+* `-e 1` : Abort the test if an error is found (remove this option for full testing of drives)
+* `-v` : Verbose mode
+* `-o` : Write list of bad blocks found (if any) to a file named `burnin-[model]_[serial number].bb`
+* `-s` : Show progress
+* `-w` : Write-mode test, writes four patterns (0xaa, 0x55, 0x44, 0x00) on every disk block
+
 The only required command-line argument is the device specifier, e.g.:
-                                                                           
+
 `./disk-burnin.sh sda`
-                                                                           
+
 ...will run the burn-in test on device /dev/sda
-                                                                           
+
 ## Dry Run Mode
 
 The script supports a 'dry run mode' which lets you check the sleep duration calculations and insure that the sequence of commands suits your needs without actually performing any operations on disks. In 'dry runs' the script does not perform any SMART tests or invoke the `sleep` or `badblocks` programs.
 
 The script was formerly distributed with 'dry run mode' enabled by default, but this is no longer the case. You will have to edit the script and set the `Dry_Run` variable to a non-zero value to enable 'dry runs'.
-                            
+
 ## `smartctl` Device Type
 
 Some users with atypical hardware environments may need to modify the script and specify the `smartctl` command device type explictly with the `-d` option. User __bcmryan__ reports success using `-d sat` with a Western Digital MyBook 8TB external drive enclosure.
@@ -70,26 +76,30 @@ Also note that `badblocks` may issue the following warning under FreeBSD/FreeNAS
 
 ## Operating System Compatibility
 
-Tested under:                                                              
+Tested under:
+
 * FreeNAS 9.10.2-U1 (FreeBSD 10.3-STABLE)
 * FreeNAS 11.1-U7 (FreeBSD 11.1-STABLE)
 * FreeNAS 11.2-U8 (FreeBSD 11.2-STABLE)
-* Ubuntu Server 16.04.2 LTS            
+* Ubuntu Server 16.04.2 LTS
 * CentOS 7.0
 
 ## Drive Models Tested
 
-The script should run successfully on any SATA disk with SMART capabilities, which includes just about all modern drives. It has been tested on these particular devices: 
+The script should run successfully on any SATA disk with SMART capabilities, which includes just about all modern drives. It has been tested on these particular devices:
+
 * HGST Deskstar NAS, UltraStar, UltraStar He10, and UltraStar He12 models
 * Western Digital Gold, Black, and Re models
 
 ## Prerequisites
-Requires the smartmontools, available at https://www.smartmontools.org     
-                                                                           
+
+Requires the smartmontools, available at [www.smartmontools.org](https://www.smartmontools.org)
+
 Uses: `grep`, `pcregrep`, `awk`, `sed`, `tr`, `sleep`, `badblocks`
 
-Tested with the static analysis tool at https://www.shellcheck.net to insure that the code is POSIX-compliant and free of issues.
+Tested with the static analysis tool at [www.shellcheck.net](https://www.shellcheck.net) to insure that the code is POSIX-compliant and free of issues.
 
 ## Author
+
 Written by Keith Nash, March 2017.
 Modified on 19 August 2020.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The script should run successfully on any SATA disk with SMART capabilities, whi
 
 Requires the smartmontools, available at [www.smartmontools.org](https://www.smartmontools.org)
 
-Uses: `grep`, `pcregrep`, `awk`, `sed`, `tr`, `sleep`, `badblocks`
+Uses: `grep`, `awk`, `sed`, `sleep`, `badblocks`
 
 Tested with the static analysis tool at [www.shellcheck.net](https://www.shellcheck.net) to insure that the code is POSIX-compliant and free of issues.
 

--- a/disk-burnin.sh
+++ b/disk-burnin.sh
@@ -147,23 +147,21 @@ if [ $# -ne 1 ]; then
   exit 2
 fi
 
-Drive=$1
+# Drive to burn-in
+readonly Drive="$1"
 
 # Set Dry_Run to a non-zero value to test out the script without actually
 # running any tests; leave it set to zero to burn-in disks.
+readonly Dry_Run=0
 
-Dry_Run=0
-
-# Directory specifiers for log and badblocks data files. Leave off the
-# trailing slash if you specify a value. Default is the current working
-# directory.
-
-Log_Dir=$(pwd)
-BB_Dir=$(pwd)
+# Directory specifiers for log and badblocks data files. Leave off the trailing
+# slash if you specify a value. Default is the current working directory.
+readonly Log_Dir="$(pwd)"
+readonly BB_Dir="$(pwd)"
 
 # Alternative:
-#Log_Dir="."
-#BB_Dir="."
+#readonly Log_Dir="."
+#readonly BB_Dir="."
 
 ########################################################################
 #
@@ -202,17 +200,14 @@ get_smart_info_value() {
 # Get disk model
 Disk_Model="$(get_smart_info_value "Device Model")"
 [ -z "${Disk_Model}" ] && Disk_Model="$(get_smart_info_value "Model Family")"
+readonly Disk_Model
 
 # Get disk serial number
-Serial_Number="$(get_smart_info_value "Serial Number")"
+readonly Serial_Number="$(get_smart_info_value "Serial Number")"
 
 # Form the log and bad blocks data filenames:
-
-Log_File="burnin-${Disk_Model}_${Serial_Number}.log"
-Log_File=$Log_Dir/$Log_File
-
-BB_File="burnin-${Disk_Model}_${Serial_Number}.bb"
-BB_File=$BB_Dir/$BB_File
+readonly Log_File="${Log_Dir}/burnin-${Disk_Model}_${Serial_Number}.log"
+readonly BB_File="${BB_Dir}/burnin-${Disk_Model}_${Serial_Number}.bb"
 
 ##################################################
 # Get SMART recommended test duration, in minutes.
@@ -239,19 +234,19 @@ get_smart_test_duration() {
 # Afterwards the completion status is repeatedly polled.
 
 # SMART short test duration
-Short_Test_Minutes="$(get_smart_test_duration "Short")"
-Short_Test_Seconds="$(( Short_Test_Minutes * 60))"
+readonly Short_Test_Minutes="$(get_smart_test_duration "Short")"
+readonly Short_Test_Seconds="$(( Short_Test_Minutes * 60))"
 
 # SMART extended test duration
-Extended_Test_Minutes="$(get_smart_test_duration "Extended")"
-Extended_Test_Seconds="$(( Extended_Test_Minutes * 60 ))"
+readonly Extended_Test_Minutes="$(get_smart_test_duration "Extended")"
+readonly Extended_Test_Seconds="$(( Extended_Test_Minutes * 60 ))"
 
 # Maximum duration the completion status is polled
-Poll_Timeout_Hours=4
-Poll_Timeout_Seconds="$(( Poll_Timeout_Hours * 60 * 60))"
+readonly Poll_Timeout_Hours=4
+readonly Poll_Timeout_Seconds="$(( Poll_Timeout_Hours * 60 * 60))"
 
 # Sleep interval between completion status polls
-Poll_Interval_Seconds=15
+readonly Poll_Interval_Seconds=15
 
 ########################################################################
 #
@@ -303,13 +298,13 @@ poll_selftest_complete()
   l_poll_duration_seconds=0
   while [ "${l_poll_duration_seconds}" -lt "${Poll_Timeout_Seconds}" ]; do
     smartctl --all "/dev/${Drive}" | grep -i "The previous self-test routine completed" > /dev/null 2<&1
-    l_status=$?
+    l_status="$?"
     if [ "${l_status}" -eq 0 ]; then
       log_info "SMART self-test succeeded"
       return 0
     fi
     smartctl --all "/dev/${Drive}" | grep -i "of the test failed." > /dev/null 2<&1
-    l_status=$?
+    l_status="$?"
     if [ "${l_status}" -eq 0 ]; then
       log_info "SMART self-test failed"
       return 0
@@ -402,7 +397,7 @@ log_header "Finished burn-in of /dev/${Drive}"
 
 # Clean up the log file:
 
-osflavor=$(uname)
+osflavor="$(uname)"
 
 if [ "${osflavor}" = "Linux" ]; then
   sed -i -e '/Copyright/d' "${Log_File}"

--- a/disk-burnin.sh
+++ b/disk-burnin.sh
@@ -131,6 +131,16 @@
 #
 ########################################################################
 
+# Check required dependencies
+readonly DEPENDENCIES="awk badblocks grep sed sleep"
+for dependency in ${DEPENDENCIES}; do
+  if ! command -v "${dependency}" > /dev/null 2>&1 ; then
+    echo "Command '${dependency}' not found. Exiting ..."
+    exit 2
+  fi
+done
+
+# Check script arguments
 if [ $# -ne 1 ]; then
   echo "Error: not enough arguments!"
   echo "Usage is: $0 drive_device_specifier"

--- a/disk-burnin.sh
+++ b/disk-burnin.sh
@@ -375,7 +375,7 @@ run_smart_test()
 {
   log_header "Run SMART $1 test"
   if [ "${DRY_RUN}" -eq 0 ]; then
-    smartctl --test="$1" --captive "/dev/${DRIVE}"
+    smartctl --test="$1" "/dev/${DRIVE}"
     log_info "SMART $1 test started, awaiting completion for $2 seconds ..."
     sleep "$2"
     poll_selftest_complete

--- a/disk-burnin.sh
+++ b/disk-burnin.sh
@@ -140,6 +140,12 @@ for dependency in ${DEPENDENCIES}; do
   fi
 done
 
+# Check if running as root
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Please run as root. Exiting ..."
+  exit 2
+fi
+
 # Check script arguments
 if [ $# -ne 1 ]; then
   echo "Error: not enough arguments!"

--- a/disk-burnin.sh
+++ b/disk-burnin.sh
@@ -18,10 +18,10 @@
 #   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 #
 #   2> Run times for large disks can take several days to complete, so it
-#      is a good idea to use tmux sessions to prevent mishaps. 
+#      is a good idea to use tmux sessions to prevent mishaps.
 #
 #   3> Must be run as 'root'.
-# 
+#
 #   4> Tests of large drives can take days to complete: use tmux!
 #
 # Performs these steps:
@@ -30,7 +30,7 @@
 #   2> Run badblocks
 #   3> Run SMART extended test
 #
-# The script sleeps after starting each SMART test, using a duration 
+# The script sleeps after starting each SMART test, using a duration
 # based on the polling interval reported by the disk, after which the
 # script will poll the disk to verify the self-test has completed.
 #
@@ -40,10 +40,10 @@
 # You should monitor the burn-in progress and watch for errors, particularly
 # any errors reported by badblocks, or these SMART errors:
 #
-#   5 Reallocated_Sector_Ct   
-# 196 Reallocated_Event_Count 
-# 197 Current_Pending_Sector  
-# 198 Offline_Uncorrectable   
+#   5 Reallocated_Sector_Ct
+# 196 Reallocated_Event_Count
+# 197 Current_Pending_Sector
+# 198 Offline_Uncorrectable
 #
 # These indicate possible problems with the drive. You therefore may
 # wish to abort the remaining tests and proceed with an RMA exchange
@@ -55,28 +55,28 @@
 #
 # badblocks is invoked with a block size of 4096, the -wsv options, and
 # the -o option to instruct it to write the list of bad blocks found (if
-# any) to a file named 'burnin-[model]_[serial number].bb'. 
-# 
+# any) to a file named 'burnin-[model]_[serial number].bb'.
+#
 # The only required command-line argument is the device specifier, e.g.:
 #
-#   ./disk-burnin.sh sda 
+#   ./disk-burnin.sh sda
 #
 # ...will run the burn-in test on device /dev/sda
 #
 # You can run the script in 'dry run mode' (see below) to check the sleep
 # duration calculations and to insure that the sequence of commands suits
-# your needs. In 'dry runs' the script does not actually perform any 
+# your needs. In 'dry runs' the script does not actually perform any
 # SMART tests or invoke the sleep or badblocks programs. The script is
 # distributed with 'dry runs' enabled, so you will need to edit the
 # Dry_Run variable below, setting it to 0, in order to actually perform
 # tests on drives.
-# 
+#
 # Before using the script on FreeBSD systems (including FreeNAS) you must
 # first execute this sysctl command to alter the kernel's geometry debug
 # flags. This allows badblocks to write to the entire disk:
 #
 #   sysctl kern.geom.debugflags=0x10
-# 
+#
 # Tested under:
 #   FreeNAS 9.10.2 (FreeBSD 10.3-STABLE)
 #   Ubuntu Server 16.04.2 LTS
@@ -94,7 +94,7 @@
 # Uses: grep, pcregrep, awk, sed, tr, sleep, badblocks
 #
 # Written by Keith Nash, March 2017
-# 
+#
 # KN, 8 Apr 2017:
 #   Added minimum test durations because some devices don't return accurate values.
 #   Added code to clean up the log file, removing copyright notices, etc.
@@ -102,16 +102,16 @@
 #   Emit test results after tests instead of full 'smartctl -a' output.
 #   Emit full 'smartctl -x' output at the end of all testing.
 #   Minor changes to log output and formatting.
-# 
+#
 # KN, 12 May 2017:
 #   Added code to poll the disk and check for completed self-tests.
-# 
+#
 #   As noted above, some disks don't report accurate values for the short and extended
-#   self-test intervals, sometimes by a significant amount. The original approach using 
+#   self-test intervals, sometimes by a significant amount. The original approach using
 #   'fudge' factors wasn't reliable and the script would finish even though the SMART
 #   self-tests had not completed. The new polling code helps insure that this doesn't
 #   happen.
-#   
+#
 #   Fixed code to work around annoying differences between sed's behavior on Linux and
 #   FreeBSD.
 #
@@ -128,7 +128,7 @@
 #		1> Short SMART test
 #		2> badblocks
 #		3> Extended SMART test
-# 
+#
 ########################################################################
 
 if [ $# -ne 1 ]; then
@@ -144,7 +144,7 @@ Drive=$1
 
 Dry_Run=0
 
-# Directory specifiers for log and badblocks data files. Leave off the 
+# Directory specifiers for log and badblocks data files. Leave off the
 # trailing slash if you specify a value. Default is the current working
 # directory.
 
@@ -227,7 +227,7 @@ poll_selftest_complete()
 # Return 0 if the test has completed, 1 if we exceed our polling timeout interval
 
   while [ $l_done -eq 0 ];
-  do  
+  do
     smartctl -a /dev/"$Drive" | grep -i "The previous self-test routine completed" > /dev/null 2<&1
     l_status=$?
     if [ $l_status -eq 0 ]; then
@@ -235,7 +235,7 @@ poll_selftest_complete()
       l_rv=0
       l_done=1
     else
-      # Check for failure    
+      # Check for failure
       smartctl -a /dev/"$Drive" | grep -i "of the test failed." > /dev/null 2<&1
       l_status=$?
       if [ $l_status -eq 0 ]; then
@@ -255,7 +255,7 @@ poll_selftest_complete()
   done
 
   return $l_rv
-} 
+}
 
 run_short_test()
 {
@@ -367,4 +367,3 @@ if [ "${osflavor}" = "FreeBSD" ]; then
   sed -i '' -e '/Vendor Specific SMART/d' "${Log_File}"
   sed -i '' -e '/SMART Error Log Version/d' "${Log_File}"
 fi
-

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2017 by Keith Nash
+Original work Copyright (c) 2017 by Keith Nash
+Modified work Copyright (c) 2020 by Michael Schnerring
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
First of all, awesome script, thanks so much for putting it together!

I found this on the iXsystems Community forum and use it on my custom Tiny Core Linux stress test thumb drive to burn-in my FreeNAS system. During testing I've come to understand the bits and pieces of this script more and more but I found some parts pretty hard to understand as a shell scripting newbie.

Some of my changes are inspired by [PR#6](Spearfoot/disk-burnin-and-testing/#6) but POSIX compliant. I used this opportunity to further my shell scripting abilities.

I'm running this version of the script on four Seagate Iron Wolf 12 TB (`ST12000VN0008`) disks on Tiny Core Linux.

## Changes

Looking at all changes at once is too much but I aimed to make the changes in each commit self-explanatory. I used multiline commit messages when changing multiple, related things at once.

#### New Features

* check if dependency commands are available
* check if running as root
* options parsing including `-h` help text; only run in non-dry mode when `-f` is provided for safety reasons
* add `.editorconfig` to streamline editor behavior for development

#### Refactoring

* remove dependencies on `tr` and `pcregrep` by just using `awk`
* use `printf` instead of `echo` to improve portability
* add documentation to functions and complex statements
* simplify code for readability
* remove code duplication

## Questions

* What's the point being able to specify two separate log directories? I have consolidated those, so one can specify the log directory with a single `-o <dir>` option
* What's the point of using 'sda' as a script option instead of the whole path '/dev/sda'? This seems kind of atypical compared to other shell commands.
* What's the point of "cleaning up" the logs at the very end? What struck me as odd was removing the copyright notice of `smartctl`. Does that info really hurt?
* What was the reason to change the script to run in non-dry mode by default? I feel like that's pretty dangerous.
* Renaming all read-only constants to uppercase ([5d702df](https://github.com/Spearfoot/disk-burnin-and-testing/commit/5d702df0a6a22350e33d751249053c7c0e7ed2cb)) is opinionated but I find [Google's styleguide](https://google.github.io/styleguide/shellguide.html#s7.2-variable-names) a very good approach to streamline shell script code. What do you think?

## TODO

* add dry-run wrapper to remove dry-run logic from test functions to remove even more code duplication
* decouple code more by splitting code into smaller functions (especially after `# ACTION BEGINS HERE`)
* Add SSD detection like in [PR#6](Spearfoot/disk-burnin-and-testing/#6) to skip `badblocks`
* update `README.md` and script header to reflect changes