### PR TITLE
extend hostname enquiry

### DIFF
--- a/disk-burnin.sh
+++ b/disk-burnin.sh
@@ -286,7 +286,7 @@ readonly LOG_DIR
 # System information
 HOSTNAME="$(hostname)"
 # Try command hostnamectl if HOSTNAME is unset or empty
-[ -z HOSTNAME ] && HOSTNAME="$(hostnamectl --static)"
+[ -z "${HOSTNAME}" ] && HOSTNAME="$(hostnamectl --static)"
 readonly HOSTNAME
 readonly OS_FLAVOR="$(uname)"
 

--- a/disk-burnin.sh
+++ b/disk-burnin.sh
@@ -285,6 +285,8 @@ readonly LOG_DIR
 
 # System information
 readonly HOSTNAME="$(hostname)"
+# Try command hostnamectl if HOSTNAME is unset or empty
+[ -z HOSTNAME ] && readonly HOSTNAME="$(hostnamectl --static)"
 readonly OS_FLAVOR="$(uname)"
 
 # SMART static information

--- a/disk-burnin.sh
+++ b/disk-burnin.sh
@@ -284,9 +284,10 @@ LOG_DIR="$(printf '%s' "${LOG_DIR}" | awk '{gsub(/\/+$/, ""); printf $1}')"
 readonly LOG_DIR
 
 # System information
-readonly HOSTNAME="$(hostname)"
+HOSTNAME="$(hostname)"
 # Try command hostnamectl if HOSTNAME is unset or empty
-[ -z HOSTNAME ] && readonly HOSTNAME="$(hostnamectl --static)"
+[ -z HOSTNAME ] && HOSTNAME="$(hostnamectl --static)"
+readonly HOSTNAME
 readonly OS_FLAVOR="$(uname)"
 
 # SMART static information


### PR DESCRIPTION
For modern systemd-based systems (e.g. Arch), where command hostname might not exist anymore