### PR TITLE
Allow `-b` & `-c` args

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The script extracts the drive model and serial number and creates a log filename
 
 `badblocks` is invoked with the following options:
 
-* `-b 8192` : Use a block size of 8192
+* `-b 8192` : Use a block size of 8192 (override this setting with the `-b` option below)
 * `-e 1` : Abort the `badblocks` test immediately if an error is found (override this setting with the `-x` option below)
 * `-c 64` : Number of concurrent blocks to check. (override this setting with the `-c` option below, but beware of memory use with high values)
 * `-v` : Verbose mode
@@ -51,12 +51,13 @@ The script extracts the drive model and serial number and creates a log filename
 
 ## Usage
 
-`./disk-burnin.sh [-h] [-e] [-c <num_blocks>] [-f] [-o <directory>] [-x] <disk>`
+`./disk-burnin.sh [-h] [-e] [-b <block_size>] [-c <num_blocks>] [-f] [-o <directory>] [-x] <disk>`
 
 ### Options
 
 * `-h`: show help text
 * `-e`: show extended help text
+* `-b`: block size (default: 8192)
 * `-c`: number of concurrent blocks to check (default: 64). Higher values will use more memory.
 * `-f`: run a full, destructive test. Disables the default 'dry-run mode'. **ALL DATA ON THE DISK WILL BE LOST!**
 * `-o <directory>`: write log files to `<directory>` (default: working directory `$(pwd)`)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The script calls `sleep` after starting each SMART test, using a duration based 
 Full SMART information is pulled after each SMART test. All output except for the `sleep` command is echoed to both the screen and log file.
 
 You should periodically monitor the burn-in progress and check for errors, particularly any errors reported by `badblocks`, or these SMART errors:
-  
+
 |ID|Attribute Name|
 |---:|---|
 |  5|Reallocated_Sector_Ct|
@@ -43,6 +43,7 @@ The script extracts the drive model and serial number and creates a log filename
 
 * `-b 8192` : Use a block size of 8192
 * `-e 1` : Abort the `badblocks` test immediately if an error is found (override this setting with the `-x` option below)
+* `-c 64` : Number of concurrent blocks to check. (override this setting with the `-c` option below, but beware of memory use with high values)
 * `-v` : Verbose mode
 * `-o` : Write list of bad blocks found (if any) to a file named `burnin-[model]_[serial number].bb`
 * `-s` : Show progress
@@ -50,12 +51,13 @@ The script extracts the drive model and serial number and creates a log filename
 
 ## Usage
 
-`./disk-burnin.sh [-h] [-e] [-f] [-o <directory>] [-x] <disk>`
+`./disk-burnin.sh [-h] [-e] [-c <num_blocks>] [-f] [-o <directory>] [-x] <disk>`
 
 ### Options
 
 * `-h`: show help text
 * `-e`: show extended help text
+* `-c`: number of concurrent blocks to check (default: 64). Higher values will use more memory.
 * `-f`: run a full, destructive test. Disables the default 'dry-run mode'. **ALL DATA ON THE DISK WILL BE LOST!**
 * `-o <directory>`: write log files to `<directory>` (default: working directory `$(pwd)`)
 * `-x`: perform a full pass of `badblocks`, using the `-e 0` option.


### PR DESCRIPTION
I continued to need to set my own `-b` and `-c` parameters for badblocks. I just went ahead and added those options to the script. Hope this is desired.

Fixes #18, at least. :)